### PR TITLE
[jjo] re-org spec-kubeapi.jsonnet to be more metrics-centric

### DIFF
--- a/jsonnet/alerts-kubeapi.jsonnet
+++ b/jsonnet/alerts-kubeapi.jsonnet
@@ -12,31 +12,23 @@ local cleanupWhiteSpace(str) = (
     if x != ''
   ])
 );
+local checks = [
+  spec.metrics[m_key].alerts[a_key]
+  for m_key in std.objectFields(spec.metrics)
+  for a_key in std.objectFields(spec.metrics[m_key].alerts)
+];
 
 {
-  // Pre-process row->panel fields to create `checks` for easier
-  // referencing from `rules`
-  checks:: [
-    {
-      formula: panel.formula,
-      alert: panel.alert,
-      alert_expr: panel.alert_expr,
-      threshold: panel.threshold,
-      annotations: panel.annotations,
-    }
-    for row in spec.rows
-    for panel in row.panels
-  ],
   // Emited `rules` as needed by prometheus alert entries
   rules:: [
     {
-      alert: check.alert,
-      expr: cleanupWhiteSpace(check.alert_expr),
+      alert: check.name,
+      expr: cleanupWhiteSpace(check.expr),
       'for': ALERTS_FOR,
       labels: ALERTS_LABELS,
       annotations: check.annotations,
     }
-    for check in $.checks
+    for check in checks
   ],
   // See https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
   groups: [

--- a/jsonnet/dash-kubeapi.jsonnet
+++ b/jsonnet/dash-kubeapi.jsonnet
@@ -5,6 +5,18 @@ local bitgraf = import 'bitnami_grafana.libsonnet';
 
 local spec = (import 'spec-kubeapi.jsonnet');
 
+local rows = [
+  {
+    local m = spec.metrics[m_key],
+    title: m.name,
+    panels: [
+      m.graphs[g_key]
+      for g_key in std.objectFields(m.graphs)
+    ],
+  }
+  for m_key in std.objectFields(spec.metrics)
+];
+
 bitgraf.dash.new(
   'SLA: Kubernetes API',
   tags=['k8s', 'api', 'sla']
@@ -18,9 +30,9 @@ bitgraf.dash.new(
     ) { thresholds: [bitgraf.threshold_gt(p.threshold)] }
     for p in x.panels
   ])
-  for x in spec.rows
+  for x in rows
 ]) {
-  local t = spec.templates_custom,
+  local t = spec.grafana.templates_custom,
   templates+: [
     template.custom(x, t[x].values, t[x].default, hide=t[x].hide)
     for x in std.objectFields(t)

--- a/jsonnet/golden/spec-kubeapi.json
+++ b/jsonnet/golden/spec-kubeapi.json
@@ -1,79 +1,101 @@
 {
-   "rows": [
-      {
-         "panels": [
-            {
-               "alert": "KubeAPIErrorRatioHigh",
-               "alert_expr": "sum by (instance)(\n  rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m])\n) /\nsum by (instance)(\n  rate(apiserver_request_count[5m])\n) > 0.01\n",
+   "grafana": {
+      "templates_custom": {
+         "api_percentile": {
+            "default": "90",
+            "hide": "",
+            "values": "50, 90, 99"
+         },
+         "verb_excl": {
+            "default": "(CONNECT|WATCH)",
+            "hide": "variable",
+            "values": "(CONNECT|WATCH)"
+         }
+      }
+   },
+   "metrics": {
+      "kube_api": {
+         "alerts": {
+            "error_ratio": {
                "annotations": {
                   "description": "Issue: Kube API Error ratio on {{ $labels.instance }} is above 0.01: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeAPIErrorRatioHigh\n",
                   "summary": "Kube API 500s ratio is High"
                },
+               "expr": "sum by (instance)(\n  rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m])\n) /\nsum by (instance)(\n  rate(apiserver_request_count[5m])\n) > 0.01\n",
+               "name": "KubeAPIErrorRatioHigh"
+            },
+            "latency": {
+               "annotations": {
+                  "description": "Issue: Kube API Latency on {{ $labels.instance }} is above 200: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeAPILatencyHigh\n",
+                  "summary": "Kube API Latency is High"
+               },
+               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, instance)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m])\n  )\n) / 1e3 > 200\n",
+               "name": "KubeAPILatencyHigh"
+            }
+         },
+         "api_percentile": "90",
+         "error_ratio_threshold": 0.01,
+         "graphs": {
+            "error_ratio": {
                "formula": "sum by (verb, code)(\n  rate(apiserver_request_count{verb!~\"$verb_excl\", code=~\"5..\"}[5m])\n) / ignoring(code) group_left\nsum by (verb)(\n  rate(apiserver_request_count[5m])\n)\n",
                "legend": "{{ verb }} - {{ code }}",
                "threshold": 0.01,
                "title": "API Error ratio 500s/total (except $verb_excl)"
             },
-            {
-               "alert": "KubeAPILatencyHigh",
-               "alert_expr": "histogram_quantile (\n  0.90,\n  sum by (le, instance)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m])\n  )\n) / 1e3 > 200\n",
-               "annotations": {
-                  "description": "Issue: Kube API Latency on {{ $labels.instance }} is above 200: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeAPILatencyHigh\n",
-                  "summary": "Kube API Latency is High"
-               },
+            "latency": {
                "formula": "histogram_quantile (\n  0.$api_percentile,\n  sum by (le, verb)(\n    rate(apiserver_request_latencies_bucket{verb!~\"$verb_excl\"}[5m])\n  )\n) / 1e3 > 0\n",
                "legend": "{{ verb }}",
                "threshold": 200,
                "title": "API $api_percentile-th latency[ms] by verb (except $verb_excl)"
             }
-         ],
-         "title": "Kube API"
+         },
+         "latency_threshold": 200,
+         "name": "Kube API",
+         "verb_excl": "(CONNECT|WATCH)"
       },
-      {
-         "panels": [
-            {
-               "alert": "KubeControllerWorkDurationHigh",
-               "alert_expr": "sum by (instance)(\n  APIServiceRegistrationController_work_duration{quantile=\"0.9\"}\n) > 100\n",
+      "kube_control_mgr": {
+         "alerts": {
+            "work_duration": {
                "annotations": {
                   "description": "Issue: Kube Control Manager on {{ $labels.instance }} work duration is above 100: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeControllerWorkDurationHigh\n",
                   "summary": "Kube Control Manager workqueue processing is slow"
                },
+               "expr": "sum by (instance)(\n  APIServiceRegistrationController_work_duration{quantile=\"0.9\"}\n) > 100\n",
+               "name": "KubeControllerWorkDurationHigh"
+            }
+         },
+         "graphs": {
+            "work_duration": {
                "formula": "sum by (instance)(\n  APIServiceRegistrationController_work_duration{quantile=\"0.9\"}\n)\n",
                "legend": "{{ instance }}",
                "threshold": 100,
                "title": "Kube Control Manager work duration"
             }
-         ],
-         "title": "Kube Control Manager"
+         },
+         "name": "Kube Control Manager",
+         "work_duration_limit": 100
       },
-      {
-         "panels": [
-            {
-               "alert": "KubeEtcdLatencyHigh",
-               "alert_expr": "max by (instance)(\n  rate(etcd_request_latencies_summary{job=\"kubernetes_apiservers\",quantile=\"0.9\"}[5m]) < Inf\n)/ 1e3 > 20\n",
+      "kube_etcd": {
+         "alerts": {
+            "latency": {
                "annotations": {
                   "description": "Issue: Kube Etcd latency on {{ $labels.instance }} above 20: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeEtcdLatencyHigh\n",
                   "summary": "Etcd Latency is High"
                },
+               "expr": "max by (instance)(\n  rate(etcd_request_latencies_summary{job=\"kubernetes_apiservers\",quantile=\"0.9\"}[5m]) < Inf\n)/ 1e3 > 20\n",
+               "name": "KubeEtcdLatencyHigh"
+            }
+         },
+         "etcd_latency_threshold": 20,
+         "graphs": {
+            "latency": {
                "formula": "max by (operation, instance)(\n  rate(etcd_request_latencies_summary{job=\"kubernetes_apiservers\",quantile=\"0.9\"}[5m]) < Inf\n)/ 1e3\n",
                "legend": "{{ instance }} - {{ operation }}",
                "threshold": 20,
                "title": "etcd 90th latency[ms] by (operation, instance)"
             }
-         ],
-         "title": "Kube Etcd"
-      }
-   ],
-   "templates_custom": {
-      "api_percentile": {
-         "default": "90",
-         "hide": "",
-         "values": "50, 90, 99"
-      },
-      "verb_excl": {
-         "default": "(CONNECT|WATCH)",
-         "hide": "variable",
-         "values": "(CONNECT|WATCH)"
+         },
+         "name": "Kube Etcd"
       }
    }
 }

--- a/jsonnet/spec-kubeapi.jsonnet
+++ b/jsonnet/spec-kubeapi.jsonnet
@@ -1,24 +1,29 @@
+local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi';
 {
-  local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi',
-  templates_custom: {
-    api_percentile: {
-      values: '50, 90, 99',
-      default: '90',
-      hide: '',
-    },
-    verb_excl: {
-      values: '(CONNECT|WATCH)',
-      default: '(CONNECT|WATCH)',
-      hide: 'variable',
+  grafana: {
+    templates_custom: {
+      api_percentile: {
+        values: '50, 90, 99',
+        default: $.metrics.kube_api.api_percentile,
+        hide: '',
+      },
+      verb_excl: {
+        values: $.metrics.kube_api.verb_excl,
+        default: $.metrics.kube_api.verb_excl,
+        hide: 'variable',
+      },
     },
   },
-  rows: [
-    local t = $.templates_custom;
-    {
-      title: 'Kube API',
-      panels: [
-        {
-          local this = self,
+  metrics: {
+    kube_api: {
+      local metric = self,
+      verb_excl: '(CONNECT|WATCH)',
+      api_percentile: '90',
+      error_ratio_threshold: 0.01,
+      latency_threshold: 200,
+      name: 'Kube API',
+      graphs: {
+        error_ratio: {
           title: 'API Error ratio 500s/total (except $verb_excl)',
           formula: |||
             sum by (verb, code)(
@@ -29,27 +34,9 @@
             )
           |||,
           legend: '{{ verb }} - {{ code }}',
-          threshold: 0.01,
-          alert: 'KubeAPIErrorRatioHigh',
-          alert_expr: |||
-            sum by (instance)(
-              rate(apiserver_request_count{verb!~"%s", code=~"5.."}[5m])
-            ) /
-            sum by (instance)(
-              rate(apiserver_request_count[5m])
-            ) > %s
-          ||| % [t.verb_excl.default, this.threshold],
-          annotations: {
-            summary: 'Kube API 500s ratio is High',
-            description: |||
-              Issue: Kube API Error ratio on {{ $labels.instance }} is above %s: {{ $value }}
-              Playbook: %s#%s
-            ||| % [this.threshold, runbook_url, this.alert],
-          },
+          threshold: metric.error_ratio_threshold,
         },
-
-        {
-          local this = self,
+        latency: {
           title: 'API $api_percentile-th latency[ms] by verb (except $verb_excl)',
           formula: |||
             histogram_quantile (
@@ -60,31 +47,56 @@
             ) / 1e3 > 0
           |||,
           legend: '{{ verb }}',
-          threshold: 200,
-          alert: 'KubeAPILatencyHigh',
-          alert_expr: |||
+          threshold: metric.latency_threshold,
+        },
+      },
+      alerts: {
+        error_ratio: {
+          local alert = self,
+          name: 'KubeAPIErrorRatioHigh',
+          expr: |||
+            sum by (instance)(
+              rate(apiserver_request_count{verb!~"%s", code=~"5.."}[5m])
+            ) /
+            sum by (instance)(
+              rate(apiserver_request_count[5m])
+            ) > %s
+          ||| % [metric.verb_excl, metric.error_ratio_threshold],
+          annotations: {
+            summary: 'Kube API 500s ratio is High',
+            description: |||
+              Issue: Kube API Error ratio on {{ $labels.instance }} is above %s: {{ $value }}
+              Playbook: %s#%s
+            ||| % [metric.error_ratio_threshold, runbook_url, alert.name],
+          },
+        },
+        latency: {
+          local alert = self,
+          name: 'KubeAPILatencyHigh',
+          expr: |||
             histogram_quantile (
               0.%s,
               sum by (le, instance)(
                 rate(apiserver_request_latencies_bucket{verb!~"%s"}[5m])
               )
             ) / 1e3 > %s
-          ||| % [t.api_percentile.default, t.verb_excl.default, this.threshold],
+          ||| % [metric.api_percentile, metric.verb_excl, metric.latency_threshold],
           annotations: {
             summary: 'Kube API Latency is High',
             description: |||
               Issue: Kube API Latency on {{ $labels.instance }} is above %s: {{ $value }}
               Playbook: %s#%s
-            ||| % [this.threshold, runbook_url, this.alert],
+            ||| % [metric.latency_threshold, runbook_url, alert.name],
           },
         },
-      ],
+      },
     },
-    {
-      title: 'Kube Control Manager',
-      panels: [
-        {
-          local this = self,
+    kube_control_mgr: {
+      local metric = self,
+      work_duration_limit: 100,
+      name: 'Kube Control Manager',
+      graphs: {
+        work_duration: {
           title: 'Kube Control Manager work duration',
           formula: |||
             sum by (instance)(
@@ -92,28 +104,34 @@
             )
           |||,
           legend: '{{ instance }}',
-          threshold: 100,
-          alert: 'KubeControllerWorkDurationHigh',
-          alert_expr: |||
+          threshold: metric.work_duration_limit,
+        },
+      },
+      alerts: {
+        work_duration: {
+          local alert = self,
+          name: 'KubeControllerWorkDurationHigh',
+          expr: |||
             sum by (instance)(
               APIServiceRegistrationController_work_duration{quantile="0.9"}
             ) > %s
-          ||| % [this.threshold],
+          ||| % [metric.work_duration_limit],
           annotations: {
             summary: 'Kube Control Manager workqueue processing is slow',
             description: |||
               Issue: Kube Control Manager on {{ $labels.instance }} work duration is above %s: {{ $value }}
               Playbook: %s#%s
-            ||| % [this.threshold, runbook_url, this.alert],
+            ||| % [metric.work_duration_limit, runbook_url, alert.name],
           },
         },
-      ],
+      },
     },
-    {
-      title: 'Kube Etcd',
-      panels: [
-        {
-          local this = self,
+    kube_etcd: {
+      local metric = self,
+      etcd_latency_threshold: 20,
+      name: 'Kube Etcd',
+      graphs: {
+        latency: {
           title: 'etcd 90th latency[ms] by (operation, instance)',
           formula: |||
             max by (operation, instance)(
@@ -121,22 +139,27 @@
             )/ 1e3
           |||,
           legend: '{{ instance }} - {{ operation }}',
-          threshold: 20,
-          alert: 'KubeEtcdLatencyHigh',
-          alert_expr: |||
+          threshold: metric.etcd_latency_threshold,
+        },
+      },
+      alerts: {
+        latency: {
+          local alert = self,
+          name: 'KubeEtcdLatencyHigh',
+          expr: |||
             max by (instance)(
               rate(etcd_request_latencies_summary{job="kubernetes_apiservers",quantile="0.9"}[5m]) < Inf
             )/ 1e3 > %s
-          ||| % [this.threshold],
+          ||| % [metric.etcd_latency_threshold],
           annotations: {
             summary: 'Etcd Latency is High',
             description: |||
               Issue: Kube Etcd latency on {{ $labels.instance }} above %s: {{ $value }}
               Playbook: %s#%s
-            ||| % [this.threshold, runbook_url, this.alert],
+            ||| % [metric.etcd_latency_threshold, runbook_url, alert.name],
           },
         },
-      ],
+      },
     },
-  ],
+  },
 }


### PR DESCRIPTION
* reorganize `spec-kubeapi.jsonnet`:
  - more `metrics` oriented
  - based on jsonnet objects rather than lists, allowing easier
    over-riding it needed 
* adapt `dash-kubeapi.jsonnet` and `alerts-kubeapi.jsonnet`
  - note *no* respective `golden/` changes for these, i.e.
  neutral on rendered output