### PR TITLE
[jjo] add SLO recording rules

### DIFF
--- a/jsonnet/Makefile
+++ b/jsonnet/Makefile
@@ -2,15 +2,16 @@ SHELL=/bin/bash
 DATE=$(shell date -I)
 OUT_GRAFANA=out/grafana
 OUT_PROMETHEUS=out/prometheus
-DASH_TARGETS=$(patsubst %.jsonnet, $(OUT_GRAFANA)/%.json, $(wildcard dash*.jsonnet))
+GRAFANA_TARGETS=$(patsubst %.jsonnet, $(OUT_GRAFANA)/%.json, $(wildcard dash*.jsonnet))
 ALERT_TARGETS=$(patsubst %.jsonnet, $(OUT_PROMETHEUS)/%.rules.yml, $(wildcard alert*.jsonnet))
+RULES_TARGETS=$(patsubst %.jsonnet, $(OUT_PROMETHEUS)/%.rules.yml, $(wildcard rules*.jsonnet))
 
 ALL_JSONNET=$(wildcard *.jsonnet)
 
 PHONY_GOLDEN=$(patsubst %.jsonnet,golden/%.json,$(ALL_JSONNET))
 PHONY_DIFF=$(patsubst %.jsonnet,%.diff,$(ALL_JSONNET))
 
-all: $(DASH_TARGETS) $(ALERT_TARGETS)
+all: $(GRAFANA_TARGETS) $(ALERT_TARGETS) $(RULES_TARGETS)
 
 test: test-fmt golden-diff
 
@@ -21,7 +22,7 @@ fix-fmt:
 	for i in $(ALL_JSONNET); do jsonnet fmt -i $$i;done
 
 clean:
-	rm -f $(DASH_TARGETS) $(ALERT_TARGETS)
+	rm -f $(GRAFANA_TARGETS) $(ALERT_TARGETS) $(RULES_TARGETS)
 
 $(OUT_PROMETHEUS)/%.rules.yml: $(OUT_PROMETHEUS)/%.json
 	@mkdir -p out/prometheus

--- a/jsonnet/alerts-kubeapi.jsonnet
+++ b/jsonnet/alerts-kubeapi.jsonnet
@@ -1,6 +1,6 @@
 local spec = import 'spec-kubeapi.jsonnet';
 
-local ALERTS_NAME = 'kubeapi';
+local ALERTS_NAME = 'kubeapi_alerts';
 local ALERTS_FOR = '15m';
 
 // Get rid of \n and duplicated whitespaces

--- a/jsonnet/dash-kubeapi.jsonnet
+++ b/jsonnet/dash-kubeapi.jsonnet
@@ -24,10 +24,10 @@ bitgraf.dash.new(
 .addRows([
   row.new(height='250px', title=x.title)
   .addPanels([
-    bitgraf.panel.new(p.title)
+    bitgraf.panel.new(p)
     .addTarget(
       bitgraf.prom(p.formula, p.legend)
-    ) { thresholds: [bitgraf.threshold_gt(p.threshold)] }
+    )
     for p in x.panels
   ])
   for x in rows

--- a/jsonnet/golden/alerts-kubeapi.json
+++ b/jsonnet/golden/alerts-kubeapi.json
@@ -23,7 +23,7 @@
                   "description": "Issue: Kube API Error ratio on {{ $labels.instance }} is above 0.01: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeAPIErrorRatioHigh\n",
                   "summary": "Kube API 500s ratio is High"
                },
-               "expr": "sum by (instance)( rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m]) ) / sum by (instance)( rate(apiserver_request_count[5m]) ) > 0.01",
+               "expr": "sum by (instance)( rate(apiserver_request_count{verb!~\"(CONNECT|WATCH|PROXY)\", code=~\"5..\"}[5m]) ) / sum by (instance)( rate(apiserver_request_count[5m]) ) > 0.01",
                "for": "5m",
                "labels": {
                   "notify_to": "slack",
@@ -37,7 +37,7 @@
                   "description": "Issue: Kube API Latency on {{ $labels.instance }} is above 200 ms: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeAPILatencyHigh\n",
                   "summary": "Kube API Latency is High"
                },
-               "expr": "histogram_quantile ( 0.90, sum by (le, instance)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m]) ) ) / 1e3 > 200",
+               "expr": "histogram_quantile ( 0.90, sum by (le, instance)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH|PROXY)\"}[5m]) ) ) / 1e3 > 200",
                "for": "5m",
                "labels": {
                   "notify_to": "slack",

--- a/jsonnet/golden/alerts-kubeapi.json
+++ b/jsonnet/golden/alerts-kubeapi.json
@@ -1,7 +1,7 @@
 {
    "groups": [
       {
-         "name": "kubeapi",
+         "name": "kubeapi_alerts",
          "rules": [
             {
                "alert": "KubeAPIUnHealthy",

--- a/jsonnet/golden/dash-kubeapi.json
+++ b/jsonnet/golden/dash-kubeapi.json
@@ -16,13 +16,178 @@
          "height": "250px",
          "panels": [
             {
+               "cacheTimeout": null,
+               "colorBackground": false,
+               "colorValue": false,
+               "colors": [
+                  "#299c46",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#d44a3a"
+               ],
+               "datasource": "$datasource",
+               "format": "percentunit",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "id": 2,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": "",
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 2,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": false,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": false
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "datasource": "$datasource",
+                     "expr": "sum_over_time(kubernetes::job:slo_kube_api_ok[$availability_span]) / sum_over_time(kubernetes::job:slo_kube_api_sample[$availability_span])\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ job }}"
+                  }
+               ],
+               "thresholds": "0.99",
+               "title": "SLO: Availaibility over $availability_span",
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "current"
+            },
+            {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 2,
+               "id": 3,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sort": "max",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "datasource": "$datasource",
+                     "expr": "sum_over_time(kubernetes::job:slo_kube_api_ok[10m]) / sum_over_time(kubernetes::job:slo_kube_api_sample[10m])\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ job }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [
+                  {
+                     "colorMode": "critical",
+                     "fill": true,
+                     "line": true,
+                     "op": "gt",
+                     "value": "0.99"
+                  }
+               ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "SLO: Availaibility over 10m",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "id": 4,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -111,7 +276,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 3,
+               "id": 5,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -214,7 +379,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 4,
+               "id": 6,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -317,7 +482,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
-               "id": 5,
+               "id": 7,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -458,6 +623,43 @@
                }
             ],
             "query": "50, 90, 99",
+            "refresh": 0,
+            "type": "custom"
+         },
+         {
+            "allValue": null,
+            "current": {
+               "text": "1d",
+               "value": "1d"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "",
+            "multi": false,
+            "name": "availability_span",
+            "options": [
+               {
+                  "text": "10m",
+                  "value": "10m"
+               },
+               {
+                  "text": "1h",
+                  "value": "1h"
+               },
+               {
+                  "text": "1d",
+                  "value": "1d"
+               },
+               {
+                  "text": "7d",
+                  "value": "7d"
+               },
+               {
+                  "text": "1m",
+                  "value": "1m"
+               }
+            ],
+            "query": "10m,1h,1d,7d,1m",
             "refresh": 0,
             "type": "custom"
          },

--- a/jsonnet/golden/dash-kubeapi.json
+++ b/jsonnet/golden/dash-kubeapi.json
@@ -629,8 +629,8 @@
          {
             "allValue": null,
             "current": {
-               "text": "1d",
-               "value": "1d"
+               "text": "7d",
+               "value": "7d"
             },
             "hide": 0,
             "includeAll": false,
@@ -655,19 +655,23 @@
                   "value": "7d"
                },
                {
-                  "text": "1m",
-                  "value": "1m"
+                  "text": "30d",
+                  "value": "30d"
+               },
+               {
+                  "text": "90d",
+                  "value": "90d"
                }
             ],
-            "query": "10m,1h,1d,7d,1m",
+            "query": "10m,1h,1d,7d,30d,90d",
             "refresh": 0,
             "type": "custom"
          },
          {
             "allValue": null,
             "current": {
-               "text": "(CONNECT|WATCH)",
-               "value": "(CONNECT|WATCH)"
+               "text": "(CONNECT|WATCH|PROXY)",
+               "value": "(CONNECT|WATCH|PROXY)"
             },
             "hide": 2,
             "includeAll": false,
@@ -676,11 +680,11 @@
             "name": "verb_excl",
             "options": [
                {
-                  "text": "(CONNECT|WATCH)",
-                  "value": "(CONNECT|WATCH)"
+                  "text": "(CONNECT|WATCH|PROXY)",
+                  "value": "(CONNECT|WATCH|PROXY)"
                }
             ],
-            "query": "(CONNECT|WATCH)",
+            "query": "(CONNECT|WATCH|PROXY)",
             "refresh": 0,
             "type": "custom"
          }

--- a/jsonnet/golden/rules-kubeapi.json
+++ b/jsonnet/golden/rules-kubeapi.json
@@ -1,0 +1,58 @@
+{
+   "groups": [
+      {
+         "name": "kubeapi_rules",
+         "rules": [
+            {
+               "expr": "sum by (job)( kubernetes::job_instance:apiserver_request_errors:ratio_rate5m)",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:apiserver_request_errors:ratio_rate5m"
+            },
+            {
+               "expr": "sum by (job, instance)( rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m])) /sum by (job, instance)( rate(apiserver_request_count[5m]))",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job_instance:apiserver_request_errors:ratio_rate5m"
+            },
+            {
+               "expr": "histogram_quantile ( 0.90, sum by (le, job)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m]) )) / 1e3",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:apiserver_latency:pctl90rate5m"
+            },
+            {
+               "expr": "histogram_quantile ( 0.90, sum by (le, job, instance)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m]) )) / 1e3",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job_instance:apiserver_latency:pctl90rate5m"
+            },
+            {
+               "expr": "sum by()(probe_success{provider=\"kubernetes\", component=\"apiserver\"})",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:probe_success"
+            },
+            {
+               "expr": "kubernetes::job:apiserver_request_errors:ratio_rate5m < bool 0.01 * kubernetes::job:apiserver_latency:pctl90rate5m < bool 200",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:slo_kube_api_ok"
+            },
+            {
+               "expr": "kubernetes::job:apiserver_request_errors:ratio_rate5m < bool Inf * kubernetes::job:apiserver_latency:pctl90rate5m < bool Inf",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:slo_kube_api_sample"
+            }
+         ]
+      }
+   ]
+}

--- a/jsonnet/golden/rules-kubeapi.json
+++ b/jsonnet/golden/rules-kubeapi.json
@@ -11,21 +11,21 @@
                "record": "kubernetes::job:apiserver_request_errors:ratio_rate5m"
             },
             {
-               "expr": "sum by (job, instance)( rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m])) /sum by (job, instance)( rate(apiserver_request_count[5m]))",
+               "expr": "sum by (job, instance)( rate(apiserver_request_count{verb!~\"(CONNECT|WATCH|PROXY)\", code=~\"5..\"}[5m])) /sum by (job, instance)( rate(apiserver_request_count[5m]))",
                "labels": {
                   "job": "kubernetes_api_slo"
                },
                "record": "kubernetes::job_instance:apiserver_request_errors:ratio_rate5m"
             },
             {
-               "expr": "histogram_quantile ( 0.90, sum by (le, job)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m]) )) / 1e3",
+               "expr": "histogram_quantile ( 0.90, sum by (le, job)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH|PROXY)\"}[5m]) )) / 1e3",
                "labels": {
                   "job": "kubernetes_api_slo"
                },
                "record": "kubernetes::job:apiserver_latency:pctl90rate5m"
             },
             {
-               "expr": "histogram_quantile ( 0.90, sum by (le, job, instance)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m]) )) / 1e3",
+               "expr": "histogram_quantile ( 0.90, sum by (le, job, instance)( rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH|PROXY)\"}[5m]) )) / 1e3",
                "labels": {
                   "job": "kubernetes_api_slo"
                },

--- a/jsonnet/golden/spec-kubeapi.json
+++ b/jsonnet/golden/spec-kubeapi.json
@@ -6,6 +6,11 @@
             "hide": "",
             "values": "50, 90, 99"
          },
+         "availability_span": {
+            "default": "1d",
+            "hide": "",
+            "values": "10m,1h,1d,7d,1m"
+         },
          "verb_excl": {
             "default": "(CONNECT|WATCH)",
             "hide": "variable",
@@ -62,6 +67,22 @@
          "api_percentile": "90",
          "error_ratio_threshold": 0.01,
          "graphs": {
+            "availability_1": {
+               "format": "percentunit",
+               "formula": "sum_over_time(kubernetes::job:slo_kube_api_ok[$availability_span]) / sum_over_time(kubernetes::job:slo_kube_api_sample[$availability_span])\n",
+               "legend": "{{ job }}",
+               "span": 2,
+               "threshold": "0.99",
+               "title": "SLO: Availaibility over $availability_span",
+               "type": "singlestat"
+            },
+            "availability_2": {
+               "formula": "sum_over_time(kubernetes::job:slo_kube_api_ok[10m]) / sum_over_time(kubernetes::job:slo_kube_api_sample[10m])\n",
+               "legend": "{{ job }}",
+               "span": 10,
+               "threshold": "0.99",
+               "title": "SLO: Availaibility over 10m"
+            },
             "error_ratio": {
                "formula": "sum by (verb, code)(\n  rate(apiserver_request_count{verb!~\"$verb_excl\", code=~\"5..\"}[5m])\n) / ignoring(code) group_left\nsum by (verb)(\n  rate(apiserver_request_count[5m])\n)\n",
                "legend": "{{ verb }} - {{ code }}",
@@ -77,6 +98,57 @@
          },
          "latency_threshold": 200,
          "name": "Kube API",
+         "rules": {
+            "error_ratio_job": {
+               "expr": "sum by (job)(\n  kubernetes::job_instance:apiserver_request_errors:ratio_rate5m\n)\n",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:apiserver_request_errors:ratio_rate5m"
+            },
+            "error_ratio_job_instance": {
+               "expr": "sum by (job, instance)(\n  rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m])\n) /\nsum by (job, instance)(\n  rate(apiserver_request_count[5m])\n)\n",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job_instance:apiserver_request_errors:ratio_rate5m"
+            },
+            "latency_job": {
+               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, job)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m])\n  )\n) / 1e3\n",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:apiserver_latency:pctl90rate5m"
+            },
+            "latency_job_instance": {
+               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, job, instance)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m])\n  )\n) / 1e3\n",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job_instance:apiserver_latency:pctl90rate5m"
+            },
+            "probe_success": {
+               "expr": "sum by()(probe_success{provider=\"kubernetes\", component=\"apiserver\"})\n",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:probe_success"
+            },
+            "slo_ok": {
+               "expr": "kubernetes::job:apiserver_request_errors:ratio_rate5m < bool 0.01 * kubernetes::job:apiserver_latency:pctl90rate5m < bool 200\n",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:slo_kube_api_ok"
+            },
+            "slo_sample": {
+               "expr": "kubernetes::job:apiserver_request_errors:ratio_rate5m < bool Inf * kubernetes::job:apiserver_latency:pctl90rate5m < bool Inf\n",
+               "labels": {
+                  "job": "kubernetes_api_slo"
+               },
+               "record": "kubernetes::job:slo_kube_api_sample"
+            }
+         },
          "verb_excl": "(CONNECT|WATCH)"
       },
       "kube_control_mgr": {
@@ -105,6 +177,7 @@
             }
          },
          "name": "Kube Control Manager",
+         "rules": { },
          "work_duration_limit": 100
       },
       "kube_etcd": {
@@ -133,7 +206,8 @@
                "title": "etcd 90th latency[ms] by (operation, instance)"
             }
          },
-         "name": "Kube Etcd"
+         "name": "Kube Etcd",
+         "rules": { }
       }
    },
    "prometheus": {

--- a/jsonnet/golden/spec-kubeapi.json
+++ b/jsonnet/golden/spec-kubeapi.json
@@ -7,14 +7,14 @@
             "values": "50, 90, 99"
          },
          "availability_span": {
-            "default": "1d",
+            "default": "7d",
             "hide": "",
-            "values": "10m,1h,1d,7d,1m"
+            "values": "10m,1h,1d,7d,30d,90d"
          },
          "verb_excl": {
-            "default": "(CONNECT|WATCH)",
+            "default": "(CONNECT|WATCH|PROXY)",
             "hide": "variable",
-            "values": "(CONNECT|WATCH)"
+            "values": "(CONNECT|WATCH|PROXY)"
          }
       }
    },
@@ -40,7 +40,7 @@
                   "description": "Issue: Kube API Error ratio on {{ $labels.instance }} is above 0.01: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeAPIErrorRatioHigh\n",
                   "summary": "Kube API 500s ratio is High"
                },
-               "expr": "sum by (instance)(\n  rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m])\n) /\nsum by (instance)(\n  rate(apiserver_request_count[5m])\n) > 0.01\n",
+               "expr": "sum by (instance)(\n  rate(apiserver_request_count{verb!~\"(CONNECT|WATCH|PROXY)\", code=~\"5..\"}[5m])\n) /\nsum by (instance)(\n  rate(apiserver_request_count[5m])\n) > 0.01\n",
                "for": "5m",
                "labels": {
                   "notify_to": "slack",
@@ -54,7 +54,7 @@
                   "description": "Issue: Kube API Latency on {{ $labels.instance }} is above 200 ms: {{ $value }}\nPlaybook: https://engineering-handbook.nami.run/sre/runbooks/kubeapi#KubeAPILatencyHigh\n",
                   "summary": "Kube API Latency is High"
                },
-               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, instance)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m])\n  )\n) / 1e3 > 200\n",
+               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, instance)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH|PROXY)\"}[5m])\n  )\n) / 1e3 > 200\n",
                "for": "5m",
                "labels": {
                   "notify_to": "slack",
@@ -107,21 +107,21 @@
                "record": "kubernetes::job:apiserver_request_errors:ratio_rate5m"
             },
             "error_ratio_job_instance": {
-               "expr": "sum by (job, instance)(\n  rate(apiserver_request_count{verb!~\"(CONNECT|WATCH)\", code=~\"5..\"}[5m])\n) /\nsum by (job, instance)(\n  rate(apiserver_request_count[5m])\n)\n",
+               "expr": "sum by (job, instance)(\n  rate(apiserver_request_count{verb!~\"(CONNECT|WATCH|PROXY)\", code=~\"5..\"}[5m])\n) /\nsum by (job, instance)(\n  rate(apiserver_request_count[5m])\n)\n",
                "labels": {
                   "job": "kubernetes_api_slo"
                },
                "record": "kubernetes::job_instance:apiserver_request_errors:ratio_rate5m"
             },
             "latency_job": {
-               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, job)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m])\n  )\n) / 1e3\n",
+               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, job)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH|PROXY)\"}[5m])\n  )\n) / 1e3\n",
                "labels": {
                   "job": "kubernetes_api_slo"
                },
                "record": "kubernetes::job:apiserver_latency:pctl90rate5m"
             },
             "latency_job_instance": {
-               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, job, instance)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH)\"}[5m])\n  )\n) / 1e3\n",
+               "expr": "histogram_quantile (\n  0.90,\n  sum by (le, job, instance)(\n    rate(apiserver_request_latencies_bucket{verb!~\"(CONNECT|WATCH|PROXY)\"}[5m])\n  )\n) / 1e3\n",
                "labels": {
                   "job": "kubernetes_api_slo"
                },
@@ -149,7 +149,7 @@
                "record": "kubernetes::job:slo_kube_api_sample"
             }
          },
-         "verb_excl": "(CONNECT|WATCH)"
+         "verb_excl": "(CONNECT|WATCH|PROXY)"
       },
       "kube_control_mgr": {
          "alerts": {

--- a/jsonnet/rules-kubeapi.jsonnet
+++ b/jsonnet/rules-kubeapi.jsonnet
@@ -1,0 +1,34 @@
+local spec = import 'spec-kubeapi.jsonnet';
+
+local RULES_NAME = 'kubeapi_rules';
+
+// Get rid of \n and duplicated whitespaces
+local cleanupWhiteSpace(str) = (
+  std.join(' ', [
+    x
+    for x in std.split(std.strReplace(str, '\n', ''), ' ')
+    if x != ''
+  ])
+);
+local rules = [
+  spec.metrics[m_key].rules[r_key]
+  for m_key in std.objectFields(spec.metrics)
+  for r_key in std.objectFields(spec.metrics[m_key].rules)
+];
+
+{
+  // Emited `rules` as needed by prometheus recording_rules entries
+  rules:: [
+    rule {
+      expr: cleanupWhiteSpace(rule.expr),
+    }
+    for rule in rules
+  ],
+  // See https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+  groups: [
+    {
+      name: RULES_NAME,
+      rules: $.rules,
+    },
+  ],
+}

--- a/jsonnet/spec-kubeapi.jsonnet
+++ b/jsonnet/spec-kubeapi.jsonnet
@@ -12,6 +12,11 @@ local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi'
   },
   grafana: {
     templates_custom: {
+      availability_span: {
+        values: '10m,1h,1d,7d,1m',
+        default: '1d',
+        hide: '',
+      },
       api_percentile: {
         values: '50, 90, 99',
         default: $.metrics.kube_api.api_percentile,
@@ -33,6 +38,26 @@ local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi'
       latency_threshold: 200,
       name: 'Kube API',
       graphs: {
+        availability_1: {
+          title: 'SLO: Availaibility over $availability_span',
+          type: 'singlestat',
+          format: 'percentunit',
+          span: 2,
+          legend: '{{ job }}',
+          formula: |||
+            sum_over_time(kubernetes::job:slo_kube_api_ok[$availability_span]) / sum_over_time(kubernetes::job:slo_kube_api_sample[$availability_span])
+          |||,
+          threshold: '0.99',
+        },
+        availability_2: {
+          title: 'SLO: Availaibility over 10m',
+          span: 10,
+          legend: '{{ job }}',
+          formula: |||
+            sum_over_time(kubernetes::job:slo_kube_api_ok[10m]) / sum_over_time(kubernetes::job:slo_kube_api_sample[10m])
+          |||,
+          threshold: '0.99',
+        },
         error_ratio: {
           title: 'API Error ratio 500s/total (except $verb_excl)',
           formula: |||
@@ -114,6 +139,83 @@ local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi'
           },
         },
       },
+      rules: {
+        common:: { labels+: { job: 'kubernetes_api_slo' } },
+        error_ratio_job_instance: self.common {
+          record: 'kubernetes::job_instance:apiserver_request_errors:ratio_rate5m',
+          expr: |||
+            sum by (job, instance)(
+              rate(apiserver_request_count{verb!~"%s", code=~"5.."}[5m])
+            ) /
+            sum by (job, instance)(
+              rate(apiserver_request_count[5m])
+            )
+          ||| % [metric.verb_excl],
+        },
+        error_ratio_job: self.common {
+          record: 'kubernetes::job:apiserver_request_errors:ratio_rate5m',
+          expr: |||
+            sum by (job)(
+              kubernetes::job_instance:apiserver_request_errors:ratio_rate5m
+            )
+          |||,
+        },
+        latency_job_instance: self.common {
+          record: 'kubernetes::job_instance:apiserver_latency:pctl%srate5m' % metric.api_percentile,
+          expr: |||
+            histogram_quantile (
+              0.%s,
+              sum by (le, job, instance)(
+                rate(apiserver_request_latencies_bucket{verb!~"%s"}[5m])
+              )
+            ) / 1e3
+          ||| % [metric.api_percentile, metric.verb_excl],
+        },
+        latency_job: self.common {
+          record: 'kubernetes::job:apiserver_latency:pctl%srate5m' % metric.api_percentile,
+          expr: |||
+            histogram_quantile (
+              0.%s,
+              sum by (le, job)(
+                rate(apiserver_request_latencies_bucket{verb!~"%s"}[5m])
+              )
+            ) / 1e3
+          ||| % [metric.api_percentile, metric.verb_excl],
+        },
+        probe_success: self.common {
+          record: 'kubernetes::job:probe_success',
+          expr: |||
+            sum by()(probe_success{provider="kubernetes", component="apiserver"})
+          |||,
+        },
+
+        // SLOs: error ratio and latency below thresholds
+        // The purpose of below metrics is to allow answering the question:
+        //   How has this SLO done in the past XXX days ?
+        //
+        // As prometheus-2.3.x can't do e.g.:
+        //   sum_over_time(kubernetes::job:slo_kube_api_ok[30d]) /
+        //   sum_over_time(kubernetes::job:slo_kube_api_ok[30d] > -Inf)
+        // b/c _over_time(<formula>) is not valid, but only plain _over_time(<metric>[time]),
+        // so we create `slo_kube_api_sample` as a way to provide all-1's, to be able to:
+        //   sum_over_time(kubernetes::job:slo_kube_api_ok[30d]) /
+        //   sum_over_time(kubernetes::job:slo_kube_api_sample[30d])
+
+        // metric to capture "SLO Ok"
+        slo_ok: self.common {
+          record: 'kubernetes::job:slo_kube_api_ok',
+          expr: |||
+            kubernetes::job:apiserver_request_errors:ratio_rate5m < bool %s * kubernetes::job:apiserver_latency:pctl%srate5m < bool %s
+          ||| % [metric.error_ratio_threshold, metric.api_percentile, metric.latency_threshold],
+        },
+        // metric always evaluating to 1 (with same labels as above)
+        slo_sample: self.common {
+          record: 'kubernetes::job:slo_kube_api_sample',
+          expr: |||
+            kubernetes::job:apiserver_request_errors:ratio_rate5m < bool Inf * kubernetes::job:apiserver_latency:pctl%srate5m < bool Inf
+          ||| % [metric.api_percentile],
+        },
+      },
     },
     kube_control_mgr: {
       local metric = self,
@@ -149,6 +251,7 @@ local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi'
           },
         },
       },
+      rules: {},
     },
     kube_etcd: {
       local metric = self,
@@ -184,6 +287,7 @@ local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi'
           },
         },
       },
+      rules: {},
     },
   },
 }

--- a/jsonnet/spec-kubeapi.jsonnet
+++ b/jsonnet/spec-kubeapi.jsonnet
@@ -13,8 +13,8 @@ local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi'
   grafana: {
     templates_custom: {
       availability_span: {
-        values: '10m,1h,1d,7d,1m',
-        default: '1d',
+        values: '10m,1h,1d,7d,30d,90d',
+        default: '7d',
         hide: '',
       },
       api_percentile: {
@@ -32,7 +32,7 @@ local runbook_url = 'https://engineering-handbook.nami.run/sre/runbooks/kubeapi'
   metrics: {
     kube_api: {
       local metric = self,
-      verb_excl: '(CONNECT|WATCH)',
+      verb_excl: '(CONNECT|WATCH|PROXY)',
       api_percentile: '90',
       error_ratio_threshold: 0.01,
       latency_threshold: 200,


### PR DESCRIPTION
* add recording rules support via new
  `rules-kubeapi.jsonnet` file

* create several recording rules, prefixed
  by `kubernetes::...` to be able to later federate them
  more easily

* support "singlestat" grafana panel, add one for
  `kubernetes::job:slo_kube_api_ok` percentage over selectable
  availability_span template, see
  https://grafana.k.dev.bitnami.net/dashboard/db/sla-kubernetes-api

* fit fmt, update `golden/` saved outputs to `make test` Ok