### PR TITLE
[jjo] fix: support both v1.15 and v1.16 pod/pod_name and container/container_name labels

### DIFF
--- a/handcrafted/kubernetes/k8s_cluster_capacity.json
+++ b/handcrafted/kubernetes/k8s_cluster_capacity.json
@@ -1087,10 +1087,10 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "topk(5,sum(container_memory_usage_bytes{image!=\"\"}) by (pod_name))",
+            "expr": "topk(5,sum(container_memory_usage_bytes{image!=\"\"}) by (pod))",
             "format": "time_series",
             "intervalFactor": 2,
-            "legendFormat": "{{pod_name}}",
+            "legendFormat": "{{pod}}",
             "refId": "A",
             "step": 10
           }
@@ -1177,11 +1177,11 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "topk(5, sum(rate(container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container_name!=\"POD\"}[2m])) by (pod_name, container_name))",
+            "expr": "topk(5, sum(rate(container_cpu_usage_seconds_total{image!=\"\",name=~\"^k8s_.*\",container!=\"POD\"}[2m])) by (pod, container))",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 2,
-            "legendFormat": "{{ container_name }} in {{ pod_name }}",
+            "legendFormat": "{{ container }} in {{ pod }}",
             "metric": "container_cpu_usage_seconds_total",
             "refId": "A",
             "step": 4

--- a/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json
+++ b/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json
@@ -36,8 +36,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "hideControls": false,
-  "id": null,
+  "iteration": 1595347057619,
   "links": [
     {
       "icon": "external link",
@@ -50,187 +49,263 @@
       "type": "dashboards"
     }
   ],
-  "rows": [
+  "panels": [
     {
-      "collapse": false,
-      "height": 300,
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$datasource",
-          "decimals": 2,
-          "fill": 1,
-          "id": 5,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "max",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "topk($top, sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) > 1e-3",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
-              "metric": "container_cpu_usage_seconds_total",
-              "refId": "A",
-              "step": 60
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "top$top container CPU usage  for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\")",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "$datasource",
-          "fill": 1,
-          "id": 3,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "max": true,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sort": "max",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "topk($top, container_memory_working_set_bytes{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"})",
-              "format": "time_series",
-              "interval": "",
-              "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
-              "metric": "container_memory_rss",
-              "refId": "A",
-              "step": 60
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "top$top container MEM usage  for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\")",
-          "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "bytes",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        }
-      ],
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 12,
+      "panels": [],
       "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": true,
       "title": "Containers CPU and MEM",
-      "titleSize": "h6"
+      "type": "row"
     },
     {
-      "collapse": true,
-      "height": "290",
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk($top, sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) > 1e-3",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
+          "metric": "container_cpu_usage_seconds_total",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "topk($top, sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\",container_name=~\"$container\"}[$_interval])) without (cpu)) > 1e-3",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{cluster}} - {{ pod_name }}/{{ container_name }}",
+          "metric": "container_cpu_usage_seconds_total",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "top$top container CPU usage  for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\")",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk($top, container_memory_working_set_bytes{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{cluster}} - {{pod}}/{{container}}",
+          "metric": "container_memory_rss",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "topk($top, container_memory_working_set_bytes{namespace=~\"$namespace\",pod_name=~\"$pod.*\",container_name=~\"$container\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{cluster}} - {{pod_name}}/{{container_name}}",
+          "metric": "container_memory_rss",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "top$top container MEM usage  for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\")",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 13,
       "panels": [
         {
           "aliasColors": {},
@@ -273,7 +348,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
+              "legendFormat": "{{cluster}} - {{pod}}/{{container}}",
               "refId": "A",
               "step": 4
             },
@@ -281,8 +356,26 @@
               "expr": "- topk($top, sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) < 0",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
+              "legendFormat": "{{cluster}} - {{pod}}/{{container}}",
               "refId": "B",
+              "step": 4
+            },
+            {
+              "expr": "topk($top, sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\",container_name=~\"$container\"}[$_interval])) without (cpu)) > 0",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}/{{container_name}}",
+              "refId": "C",
+              "step": 4
+            },
+            {
+              "expr": "- topk($top, sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\",container_name=~\"$container\"}[$_interval])) without (cpu)) < 0",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}/{{container_name}}",
+              "refId": "D",
               "step": 4
             }
           ],
@@ -363,7 +456,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod}}/{{ container }}",
+              "legendFormat": "{{cluster}} - {{pod}}/{{container}}",
               "refId": "A",
               "step": 4
             },
@@ -371,8 +464,26 @@
               "expr": "- topk($top, sum(rate(container_fs_writes_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) < 0",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod}}/{{ container }}",
+              "legendFormat": "{{cluster}} - {{pod}}/{{container}}",
               "refId": "B",
+              "step": 4
+            },
+            {
+              "expr": "topk($top, sum(rate(container_fs_reads_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\",container_name=~\"$container\"}[$_interval])) without (cpu)) > 0",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}/{{container_name}}",
+              "refId": "C",
+              "step": 4
+            },
+            {
+              "expr": "- topk($top, sum(rate(container_fs_writes_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\",container_name=~\"$container\"}[$_interval])) without (cpu)) < 0",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}/{{container_name}}",
+              "refId": "D",
               "step": 4
             }
           ],
@@ -414,15 +525,13 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": true,
       "title": "Containers I/O",
-      "titleSize": "h6"
+      "type": "row"
     },
     {
-      "collapse": true,
-      "height": 284,
+      "collapsed": true,
+      "datasource": null,
+      "id": 14,
       "panels": [
         {
           "aliasColors": {},
@@ -465,16 +574,34 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod}}",
+              "legendFormat": "{{cluster}} - {{pod}}",
               "refId": "A",
               "step": 4
             },
             {
-              "expr": "- topk($top, sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\",container=~\"$container\",pod=~\"$pod.*\"}[$_interval])) without (cpu)) < 0",
+              "expr": "- topk($top, sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\",pod=~\"$pod.*\"}[$_interval])) without (cpu)) < 0",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod}}",
+              "legendFormat": "{{cluster}} - {{pod}}",
               "refId": "B",
+              "step": 4
+            },
+            {
+              "expr": "topk($top, sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\"}[$_interval])) without (cpu)) > 0",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}",
+              "refId": "C",
+              "step": 4
+            },
+            {
+              "expr": "- topk($top, sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\"}[$_interval])) without (cpu)) < 0",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}",
+              "refId": "D",
               "step": 4
             }
           ],
@@ -555,7 +682,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod }}",
+              "legendFormat": "{{cluster}} - {{pod}}",
               "refId": "A",
               "step": 4
             },
@@ -564,8 +691,27 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod }}",
+              "legendFormat": "{{cluster}} - {{pod}}",
               "refId": "B",
+              "step": 4
+            },
+            {
+              "expr": "topk($top, sum(rate(container_network_receive_packets_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\"}[$_interval])) without (cpu)) > 0",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}",
+              "refId": "C",
+              "step": 4
+            },
+            {
+              "expr": "- topk($top, sum(rate(container_network_transmit_packets_total{namespace=~\"$namespace\",pod_name=~\"$pod.*\"}[$_interval])) without (cpu)) < 0",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{cluster}} - {{pod_name}}",
+              "refId": "D",
               "step": 4
             }
           ],
@@ -607,14 +753,12 @@
         }
       ],
       "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": true,
       "title": "Pods Network traffic",
-      "titleSize": "h6"
+      "type": "row"
     }
   ],
-  "schemaVersion": 14,
+  "refresh": false,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "k8s",
@@ -626,12 +770,16 @@
     "list": [
       {
         "hide": 0,
+        "includeAll": false,
         "label": null,
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
@@ -669,12 +817,14 @@
           }
         ],
         "query": "5,10,20,100",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "allValue": ".+",
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -684,6 +834,7 @@
         "query": "kube_pod_container_status_running",
         "refresh": 1,
         "regex": "/.*,namespace=\"([^\"]+)\".*/",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -695,6 +846,7 @@
         "allValue": ".*",
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": "pod",
@@ -704,6 +856,7 @@
         "query": "kube_pod_container_status_running",
         "refresh": 1,
         "regex": "/.*pod=\"([a-z0-9-]+?)(?:-([0-9a-f]+-)?.....(-.....)?|-[0-9]+)?\".*/",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -715,6 +868,7 @@
         "allValue": ".+",
         "current": {},
         "datasource": "$datasource",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": "container",
@@ -724,6 +878,7 @@
         "query": "kube_pod_container_status_running",
         "refresh": 1,
         "regex": "/.*container=\"([^\"]+)\".*/",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -736,8 +891,9 @@
         "auto_count": 30,
         "auto_min": "5m",
         "current": {
-          "text": "2m",
-          "value": "2m"
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval"
         },
         "hide": 2,
         "label": null,
@@ -801,6 +957,7 @@
         ],
         "query": "5m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
         "refresh": 2,
+        "skipUrlSync": false,
         "type": "interval"
       }
     ]
@@ -836,5 +993,6 @@
   },
   "timezone": "",
   "title": "Kubernetes resource usage per namespace and pod",
+  "uid": "XLehfQoWk",
   "version": 5
 }

--- a/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json
+++ b/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json
@@ -1,25 +1,4 @@
 {
-  "__inputs": [],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.6.0"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -36,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1595347057619,
+  "iteration": 1595347057621,
   "links": [
     {
       "icon": "external link",
@@ -313,7 +292,21 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "hiddenSeries": false,
           "id": 7,
           "legend": {
             "alignAsTable": true,
@@ -332,13 +325,15 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 12,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -381,6 +376,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "top$top container IO +R -W for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\") [bytes/sec]",
           "tooltip": {
@@ -413,7 +409,11 @@
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -421,7 +421,21 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "hiddenSeries": false,
           "id": 8,
           "legend": {
             "alignAsTable": true,
@@ -440,13 +454,15 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 12,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -489,6 +505,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "top$top container IO +R -W ns=\"$namespace\" (pod=\"$pod\",container=\"$container\") [iops]",
           "tooltip": {
@@ -521,7 +538,11 @@
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "repeat": null,
@@ -531,6 +552,12 @@
     {
       "collapsed": true,
       "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
       "id": 14,
       "panels": [
         {
@@ -539,7 +566,21 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 19
+          },
+          "hiddenSeries": false,
           "id": 10,
           "legend": {
             "alignAsTable": true,
@@ -558,13 +599,15 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 12,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -607,6 +650,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "top$top Pod Network +RX -TX ns=\"$namespace\" (pod=\"$pod\") [Bytes/sec]",
           "tooltip": {
@@ -639,7 +683,11 @@
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -647,7 +695,21 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "hiddenSeries": false,
           "id": 11,
           "legend": {
             "alignAsTable": true,
@@ -666,13 +728,15 @@
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
           "percentage": false,
           "pointradius": 5,
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 12,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -717,6 +781,7 @@
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
           "title": "top$top Pod Network +RX -TX ns=\"$namespace\" (pod=\"$pod\") [pkts/sec]",
           "tooltip": {
@@ -749,7 +814,11 @@
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "repeat": null,
@@ -822,7 +891,14 @@
       },
       {
         "allValue": ".+",
-        "current": {},
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": "$datasource",
         "definition": "",
         "hide": 0,
@@ -844,7 +920,11 @@
       },
       {
         "allValue": ".*",
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
         "definition": "",
         "hide": 0,
@@ -866,7 +946,11 @@
       },
       {
         "allValue": ".+",
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
         "definition": "",
         "hide": 0,
@@ -893,16 +977,16 @@
         "current": {
           "selected": false,
           "text": "auto",
-          "value": "$__auto_interval"
+          "value": "$__auto_interval__interval"
         },
         "hide": 2,
         "label": null,
         "name": "_interval",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "auto",
-            "value": "$__auto_interval"
+            "value": "$__auto_interval__interval"
           },
           {
             "selected": false,
@@ -968,7 +1052,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",
@@ -994,5 +1077,5 @@
   "timezone": "",
   "title": "Kubernetes resource usage per namespace and pod",
   "uid": "XLehfQoWk",
-  "version": 5
+  "version": 6
 }

--- a/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json
+++ b/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json
@@ -92,11 +92,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk($top, sum(rate(container_cpu_usage_seconds_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\",container_name=~\"$container_name\"}[$_interval])) without (cpu)) > 1e-3",
+              "expr": "topk($top, sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) > 1e-3",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name }}/{{ container_name }}",
+              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
               "metric": "container_cpu_usage_seconds_total",
               "refId": "A",
               "step": 60
@@ -105,7 +105,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "top$top container CPU usage  for ns=\"$namespace\" (pod_name=\"$pod_name\",container_name=\"$container_name\")",
+          "title": "top$top container CPU usage  for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\")",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -174,11 +174,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk($top, container_memory_working_set_bytes{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\",container_name=~\"$container_name\"})",
+              "expr": "topk($top, container_memory_working_set_bytes{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"})",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name }}/{{ container_name }}",
+              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
               "metric": "container_memory_rss",
               "refId": "A",
               "step": 60
@@ -187,7 +187,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "top$top container MEM usage  for ns=\"$namespace\" (pod_name=\"$pod_name\",container_name=\"$container_name\")",
+          "title": "top$top container MEM usage  for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\")",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -268,20 +268,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk($top, sum(rate(container_fs_reads_bytes_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\",container_name=~\"$container_name\"}[$_interval])) without (cpu)) > 0",
+              "expr": "topk($top, sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) > 0",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name }}/{{ container_name }}",
+              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
               "refId": "A",
               "step": 4
             },
             {
-              "expr": "- topk($top, sum(rate(container_fs_writes_bytes_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\",container_name=~\"$container_name\"}[$_interval])) without (cpu)) < 0",
+              "expr": "- topk($top, sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) < 0",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name }}/{{ container_name }}",
+              "legendFormat": "{{cluster}} - {{ pod }}/{{ container }}",
               "refId": "B",
               "step": 4
             }
@@ -289,7 +289,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "top$top container IO +R -W for ns=\"$namespace\" (pod_name=\"$pod_name\",container_name=\"$container_name\") [bytes/sec]",
+          "title": "top$top container IO +R -W for ns=\"$namespace\" (pod=\"$pod\",container=\"$container\") [bytes/sec]",
           "tooltip": {
             "shared": true,
             "sort": 1,
@@ -358,20 +358,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk($top, sum(rate(container_fs_reads_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\",container_name=~\"$container_name\"}[$_interval])) without (cpu)) > 0",
+              "expr": "topk($top, sum(rate(container_fs_reads_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) > 0",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name}}/{{ container_name }}",
+              "legendFormat": "{{cluster}} - {{ pod}}/{{ container }}",
               "refId": "A",
               "step": 4
             },
             {
-              "expr": "- topk($top, sum(rate(container_fs_writes_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\",container_name=~\"$container_name\"}[$_interval])) without (cpu)) < 0",
+              "expr": "- topk($top, sum(rate(container_fs_writes_total{namespace=~\"$namespace\",pod=~\"$pod.*\",container=~\"$container\"}[$_interval])) without (cpu)) < 0",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name}}/{{ container_name }}",
+              "legendFormat": "{{cluster}} - {{ pod}}/{{ container }}",
               "refId": "B",
               "step": 4
             }
@@ -379,7 +379,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "top$top container IO +R -W ns=\"$namespace\" (pod_name=\"$pod_name\",container_name=\"$container_name\") [iops]",
+          "title": "top$top container IO +R -W ns=\"$namespace\" (pod=\"$pod\",container=\"$container\") [iops]",
           "tooltip": {
             "shared": true,
             "sort": 1,
@@ -460,20 +460,20 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk($top, sum(rate(container_network_receive_bytes_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\"}[$_interval])) without (cpu)) > 0",
+              "expr": "topk($top, sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\",pod=~\"$pod.*\"}[$_interval])) without (cpu)) > 0",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name}}",
+              "legendFormat": "{{cluster}} - {{ pod}}",
               "refId": "A",
               "step": 4
             },
             {
-              "expr": "- topk($top, sum(rate(container_network_transmit_bytes_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",container_name=~\"$container_name\",pod_name=~\"$pod_name.*\"}[$_interval])) without (cpu)) < 0",
+              "expr": "- topk($top, sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\",container=~\"$container\",pod=~\"$pod.*\"}[$_interval])) without (cpu)) < 0",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name}}",
+              "legendFormat": "{{cluster}} - {{ pod}}",
               "refId": "B",
               "step": 4
             }
@@ -481,7 +481,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "top$top Pod Network +RX -TX ns=\"$namespace\" (pod_name=\"$pod_name\") [Bytes/sec]",
+          "title": "top$top Pod Network +RX -TX ns=\"$namespace\" (pod=\"$pod\") [Bytes/sec]",
           "tooltip": {
             "shared": true,
             "sort": 1,
@@ -550,21 +550,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk($top, sum(rate(container_network_receive_packets_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\"}[$_interval])) without (cpu)) > 0",
+              "expr": "topk($top, sum(rate(container_network_receive_packets_total{namespace=~\"$namespace\",pod=~\"$pod.*\"}[$_interval])) without (cpu)) > 0",
               "format": "time_series",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name }}",
+              "legendFormat": "{{cluster}} - {{ pod }}",
               "refId": "A",
               "step": 4
             },
             {
-              "expr": "- topk($top, sum(rate(container_network_transmit_packets_total{kubernetes_io_role=\"$role\",namespace=~\"$namespace\",pod_name=~\"$pod_name.*\"}[$_interval])) without (cpu)) < 0",
+              "expr": "- topk($top, sum(rate(container_network_transmit_packets_total{namespace=~\"$namespace\",pod=~\"$pod.*\"}[$_interval])) without (cpu)) < 0",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
-              "legendFormat": "{{cluster}} - {{ pod_name }}",
+              "legendFormat": "{{cluster}} - {{ pod }}",
               "refId": "B",
               "step": 4
             }
@@ -572,7 +572,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "top$top Pod Network +RX -TX ns=\"$namespace\" (pod_name=\"$pod_name\") [pkts/sec]",
+          "title": "top$top Pod Network +RX -TX ns=\"$namespace\" (pod=\"$pod\") [pkts/sec]",
           "tooltip": {
             "shared": true,
             "sort": 1,
@@ -633,26 +633,6 @@
         "refresh": 1,
         "regex": "",
         "type": "datasource"
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "$datasource",
-        "hide": 2,
-        "includeAll": false,
-        "label": null,
-        "multi": false,
-        "name": "role",
-        "options": [],
-        "query": "up{kubernetes_io_role!=\"\"}",
-        "refresh": 1,
-        "regex": "/.*kubernetes_io_role=\"(.+)\".*/",
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
       },
       {
         "allValue": null,
@@ -719,7 +699,7 @@
         "includeAll": true,
         "label": "pod",
         "multi": false,
-        "name": "pod_name",
+        "name": "pod",
         "options": [],
         "query": "kube_pod_container_status_running",
         "refresh": 1,
@@ -739,7 +719,7 @@
         "includeAll": true,
         "label": "container",
         "multi": false,
-        "name": "container_name",
+        "name": "container",
         "options": [],
         "query": "kube_pod_container_status_running",
         "refresh": 1,
@@ -856,5 +836,5 @@
   },
   "timezone": "",
   "title": "Kubernetes resource usage per namespace and pod",
-  "version": 4
+  "version": 5
 }


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#removed-metrics, `s/pod_name/pod/`, `s/container_name/container/`